### PR TITLE
Api gateway upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
 		}
 	],
 	"require": {
-		"guzzlehttp/guzzle": "^6.0"
+		"guzzlehttp/guzzle": "3.8 - 6.5"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "4.0.*"
+		"phpunit/phpunit": "4.8 - 5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Minutemailer/ContactLists.php
+++ b/src/Minutemailer/ContactLists.php
@@ -4,12 +4,148 @@ namespace Minutemailer;
 
 class ContactLists extends RestAPI
 {
-    public $endpoint = 'contactlists';
+    public $endpoint = 'contact-lists';
 
-    public function subscribe($data)
+    /**
+     * @deprecated
+     * @param mixed $data default null
+     * @return ContactLists $this
+     */
+    public function subscribe($data = null)
     {
-        $this->segment = 'subscribe';
+        $this->deprecated(__METHOD__, 'Contacts->create');
+
+        return $this;
+    }
+
+    /**
+     * @param int $limit default 10
+     * @param int $page default 1
+     * @param int $with_contacts_count 0|1 default 1
+     * @param string $query
+     * @param string[] $include_lists default []
+     * @return mixed
+     */
+    public function getContactlists($limit = 10, $page = 1, $with_contacts_count = 1, $query = '', array $include_lists = array())
+    {
+        $data = array(
+            'limit' => $limit,
+            'page' => $page,
+            'with_contacts_count' => $with_contacts_count,
+        );
+        if ($query != null) $data['query'] = $query;
+        if (count($include_lists)) $data['include_lists'] = implode(',', $include_lists);
+        $response = $this->get($data);
+
+        return $response;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function show()
+    {
+        $response = $this->get();
+
+        return $response;
+    }
+
+    /**
+     * @param string[] $contact_lists
+     * @return mixed
+     */
+    public function batchDelete($contact_lists)
+    {
+        $data = array(
+            'contact_lists' => $contact_lists,
+        );
+        $this->segment = 'batch';
+        $response = $this->delete($data);
+
+        return $response;
+    }
+
+    /**
+     * @param string $name
+     * @param  array $metadata
+     * @return mixed
+     */
+    public function create($name, array $metadata = array())
+    {
+        $data = array(
+            'name' => $name,
+            'metadata' => $metadata,
+        );
         $response = $this->post($data);
+
+        return $response;
+    }
+
+    /**
+     * @param mixed $data
+     */
+    public function update($data)
+    {
+        $response = $this->put($data);
+
+        return $response;
+    }
+
+    /**
+     * @param string $contact_uuid
+     * @return mixed
+     */
+    public function addContact($contact_uuid)
+    {
+        $this->segment = 'add-contact/' . $contact_uuid;
+        $response = $this->put();
+
+        return $response;
+    }
+
+    /**
+     * @param string $contact_uuid
+     * @param  mixed $data
+     * @return mixed
+     */
+    public function updateContact($contact_uuid, $data)
+    {
+        $this->segment = 'contacts/' . $contact_uuid;
+        $response = $this->put($data);
+
+        return $response;
+    }
+
+    /**
+     * @param string $contact_uuid
+     * @return mixed
+     */
+    public function removeContact($contact_uuid)
+    {
+        $this->segment = 'remove-contact/' . $contact_uuid;
+        $response = $this->put();
+
+        return $response;
+    }
+
+    /**
+     * @param string[] $contacts contact UUID<string>
+     */
+    public function batchAddContact($contacts)
+    {
+        $this->segment = 'batch-add-contacts';
+        $response = $this->put(array('contacts' => $contacts));
+
+        return $response;
+    }
+
+    /**
+     * @param string[] $contacts contact UUID<string>
+     */
+    public function batchRemoveContact($contacts)
+    {
+        $this->segment = 'batch-remove-contacts';
+        $response = $this->put(array('contacts' => $contacts));
 
         return $response;
     }

--- a/src/Minutemailer/Contacts.php
+++ b/src/Minutemailer/Contacts.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Minutemailer;
+
+class Contacts extends RestAPI
+{
+    /**
+     * @var string
+     */
+    public $endpoint = 'contacts';
+
+    /**
+     * @param int $limit default 10
+     * @param int $page default 1
+     * @param \DateTimeInterface|null $since default null
+     * @param string[] $fields default []
+     * @return mixed
+     */
+    public function get($limit = 10, $page = 1, $since = null, array $fields = array())
+    {
+        $data = array(
+            'limit' => $limit,
+            'page' => $page,
+        );
+        if ($since instanceof \DateTimeInterface) $data['since'] = $since->format('Y-m-d');
+        if (count($fields) > 0) $data['fields'] = implode(',', $fields);
+        $response = parent::get($data);
+
+        return $response;
+    }
+
+    /**
+     * @param string[] $contactIds UUID<string>
+     * @param string[] $fields
+     */
+    public function batchShow(array $contactIds, array $fields)
+    {
+        $data = array(
+            'contacts' => $contactIds,
+            'fields' => $fields,
+        );
+        $this->id = 'batch-show';
+        $response = $this->getWithBody($data);
+
+        return $response;
+    }
+
+    /**
+     * @param string[] $contactIds UUID<string>
+     * @return mixed
+     */
+    public function batchDelete(array $contactIds)
+    {
+        $data = array(
+            'contacts' => $contactIds,
+        );
+        $this->id = 'batch';
+        $this->delete($data);
+    }
+
+    /**
+     * @param string[] $contactIds UUID<string>
+     * @param string $origin UUID
+     * @param string $destination UUID
+     * @return mixed
+     */
+    public function batchMove(array $contactIds, $origin, $destination)
+    {
+        $data = array(
+            'contacts' => $contactIds,
+            'origin' => $origin,
+            'destination' => $destination,
+        );
+        $this->id = 'batch-move';
+        $response = $this->put($data);
+
+        return $response;
+    }
+
+    /**
+     * @param string $email
+     * @param  array $fields
+     * @param string[] $contactListIds UUID<string>
+     * @return mixed
+     */
+    public function create($email, array $fields, $contactListIds)
+    {
+        $data = array(
+            'email' => $email,
+            'status' => 1,
+            'contact_lists' => $contactListIds,
+        );
+        // Elevate top-level fields
+        if (isset($fields['email'])) unset($fields['email']);
+        if (isset($fields['status'])) unset($fields['status']);
+        if (isset($fields['contact_lists'])) unset($fields['contact_lists']);
+        foreach (['first_name', 'last_name', 'phone', 'address', 'postal_code', 'city', 'note'] as $key) {
+            if (!empty($fields[$key])) {
+                $data[$key] = $fields[$key];
+                unset($fields[$key]);
+            }
+        }
+        if (count($fields) > 0) {
+            $data['fields'] = $fields;
+        }
+
+        $response = $this->post($data);
+        return $response;
+        
+    }
+
+    /**
+     * @param  array $fields
+     * @return mixed
+     */
+    public function update(array $fields)
+    {
+        $data = array();
+        // Elevate top-level fields
+        foreach (['email', 'first_name', 'last_name', 'phone', 'address', 'postal_code', 'city', 'note', 'status'] as $key) {
+            if (!empty($fields[$key])) {
+                $data[$key] = $fields[$key];
+                unset($fields[$key]);
+            }
+        }
+        $data['fields'] = $fields;
+        $response = $this->put($data);
+
+        return $response;
+    }
+
+    /**
+     * @param  array $data
+     * @return mixed
+     */
+    public function unsubscribe()
+    {
+        $this->segment = __METHOD__;
+        $response = $this->put();
+
+        return $response;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function options()
+    {
+        $response = $this->get();
+
+        return $response;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function show()
+    {
+        $response = $this->get();
+
+        return $response;
+    }
+
+}

--- a/src/Minutemailer/Fields.php
+++ b/src/Minutemailer/Fields.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Minutemailer;
+
+class Fields extends RestAPI
+{
+    /**
+     * @var string
+     */
+    public $endpoint = 'fields';
+
+    /**
+     * @param  string $fieldId
+     * @return mixed
+     */
+    public function remove($fieldId)
+    {
+        $this->id = $fieldId;
+        $response = $this->delete();
+
+        return $response;
+    }
+
+    /**
+     * @param  string $fieldId UUID
+     * @return mixed
+     */
+    public function show($fieldId)
+    {
+        $this->id = $fieldId;
+        $response = $this->get();
+
+        return $response;
+    }
+
+    /**
+     * @param  array  $data
+     * @return mixed
+     */
+    public function create($data)
+    {
+        $response = $this->post($data);
+
+        return $response;
+    }
+
+    /**
+     * @param  string $fieldId UUID
+     * @param  array  $data
+     * @return mixed
+     */
+    public function update($fieldId, $data)
+    {
+        $this->id = $fieldId;
+        $response = $this->put($data);
+
+        return $response;
+    }
+
+    /**
+     * @param  int[]  $data UUID<string:int>
+     * @return mixed
+     */
+    public function reorder($data)
+    {
+        $this->id = __METHOD__;
+        $response = $this->put($data);
+
+        return $response;
+    }
+
+
+}

--- a/src/Minutemailer/Minutemailer.php
+++ b/src/Minutemailer/Minutemailer.php
@@ -1,32 +1,56 @@
 <?php namespace Minutemailer;
 
-use \GuzzleHttp\Client;
-
 class Minutemailer
 {
-
     private $baseUrl;
-    private $currentEndpoint;
-    private $version;
     private $clientSecret;
-    private $clientId;
-    private $client;
+    protected $client;
 
     public function __construct($personalAccessToken)
     {
-        $this->baseUrl = 'https://api.minutemailer.com';
-        $this->version = 'v1';
-        $this->personalAccessToken = $personalAccessToken;
-        $this->client = new Client([
-            'base_uri' => $this->baseUrl . '/' . $this->version . '/',
-            'headers' => [
-                'Accept' => 'application/json',
-                'Authorization' => 'Bearer ' . $this->personalAccessToken
-            ]
-        ]);
+        $this->baseUrl = 'https://api-gateway.minutemailer.com';
+        $this->clientSecret = $personalAccessToken;
+        if (class_exists('Guzzle\\Common\\Version')) {
+            $this->client = new \Guzzle\Http\Client($this->baseUrl, array(
+                'request.options' => array(
+                    'headers' => array(
+                        'Accept' => 'application/json',
+                        'X-Auth-Token' => $this->clientSecret,
+                    ),
+                ),
+            ));
+        }
+        else {
+            $this->client = new \GuzzleHttp\Client(array(
+                'base_uri' => $this->baseUrl . '/',
+                'headers' => array(
+                    'Accept' => 'application/json',
+                    'X-Auth-Token' => $this->clientSecret,
+                ),
+            ));
+        }
     }
 
-    public function contact_lists($id)
+    /**
+     * @param string $id field UUID
+     */
+    public function fields($id = null)
+    {
+        return new Fields($this->client, $id);
+    }
+
+    /**
+     * @param string $id contact UUID
+     */
+    public function contacts($id = null)
+    {
+        return new Contacts($this->client, $id);
+    }
+
+    /**
+     * @param string $id contactlist UUID
+     */
+    public function contact_lists($id = null)
     {
         return new ContactLists($this->client, $id);
     }

--- a/src/Minutemailer/RestAPI.php
+++ b/src/Minutemailer/RestAPI.php
@@ -4,12 +4,28 @@ namespace Minutemailer;
 
 class RestAPI
 {
+    /**
+     * @var string
+     */
     public $endpoint;
+    /**
+     * @var object
+     */
     public $client;
+    /**
+     * @var string
+     */
     public $id;
+    /**
+     * @var string
+     */
     public $segment;
 
-    public function __construct($client, $id = null)
+    /**
+     * @param object $client
+     * @param string $id
+     */
+    public function __construct($client, $id = '')
     {
         $this->client = $client;
         $this->id = $id;
@@ -19,11 +35,11 @@ class RestAPI
     {
         $endpoint = $this->endpoint;
 
-        if ($this->id) {
+        if (strlen($this->id) > 0) {
             $endpoint .= '/' . $this->id;
         }
 
-        if ($this->segment) {
+        if (strlen($this->segment) > 0) {
             $endpoint .= '/' . $this->segment;
         }
 
@@ -33,13 +49,13 @@ class RestAPI
     /**
      * Get resource
      * @param  array  $query
-     * @return GuzzleHttp\Psr7\Response
+     * @return mixed
      */
-    public function get($query = [])
+    public function get($query = array())
     {
         $endpoint = $this->getEndpoint();
 
-        $response = $this->client->get($endpoint, ['query' => $query]);
+        $response = $this->client->get($endpoint, array('query' => $query));
         $response = json_decode($response->getBody());
 
         return $response;
@@ -48,15 +64,68 @@ class RestAPI
     /**
      * Post data
      * @param  array  $data
-     * @return GuzzleHttp\Psr7\Response
+     * @return mixed
      */
-    public function post($data = [])
+    public function post($data = array())
     {
         $endpoint = $this->getEndpoint();
 
-        $response = $this->client->post($endpoint, ['form_params' => $data]);
+        $response = $this->client->post($endpoint, array('json' => $data));
         $response = json_decode($response->getBody());
 
         return $response;
+    }
+
+    /**
+     * Delete data
+     * @param  array  $data
+     * @return mixed
+     */
+    public function delete($data = array())
+    {
+        $endpoint = $this->getEndpoint();
+
+        $response = $this->client->delete($endpoint, array('json' => $data));
+        $response = json_decode($response->getBody());
+
+        return $response;
+    }
+
+    /**
+     * @param  mixed  $data
+     * @return mixed
+     */
+    public function put($data = array())
+    {
+        $endpoint = $this->getEndpoint();
+
+        $response = $this->client->put($endpoint, array('json' => $data));
+        $response = json_decode($response->getBody());
+
+        return $response;
+    }
+
+    /**
+     * @param  array  $data
+     * @return mixed
+     */
+    public function getWithBody($data = array())
+    {
+        $endpoint = $this->getEndpoint();
+
+        $response = $this->client->request('get', $endpoint, array('json' => $data));
+        $response = json_decode($response->getBody());
+
+        return $response;
+    }
+
+    /**
+     * @param  string  $method
+     * @param  string  $replacedBy
+     * @return void
+     */
+    protected function deprecated($method, $replacedBy)
+    {
+        trigger_error($method.' is replaced by '.$replacedBy, E_USER_DEPRECATED);
     }
 }


### PR DESCRIPTION
Updated broken code to work with recent API definition, maintained PHP 5.3 compatibility even though required SSL-version are not available on those platforms; but technically could be provided by for instance a go-between proxypass.

Closes #1 